### PR TITLE
Update CirrusMDSDK to 3.2.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.2 / 2020-07-27
+* Updated the pinned SSL certificates.
+
+--- 
+# DEPRECATED: All builds below this line are deprecated and will not work starting on 8/20/2020
+
 # 3.2.1 / 2020-06-25
 * Fixed an ID casting issue.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation('com.github.CirrusMD:cirrusmd-android:3.2.1') {
+    implementation('com.github.CirrusMD:cirrusmd-android:3.2.2') {
 //        Only exclude this dependency if you're sure your plan does not use video. Check with your account manager if you have questions.
 //        exclude group: 'com.opentok.android', module: 'opentok-android-sdk'
     }


### PR DESCRIPTION
## Description
- Update CirrusMDSDK in the example app to 3.2.2.
- Added deprecation notice to CHANGELOG.

## Motivation and Context
Version 3.2.2 of the CirrusMDSDK contains updates to the pinned certificates.

Deprecation note: All version older than 3.2.2 are deprecated and will not working starting on 8/20/2020. This note has been added to the CHANGELOG.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [x] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
