### PR TITLE
Add version 3.1.2 to the CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 3.2.2 / 2020-07-27
-* Updated the pinned SSL certificates.
+* Updated the pinned SSL certificates. Based off of 3.2.1.
+
+# 3.1.2 / 2020-07-27
+* Updated the pinned SSL certificates. Based off of 3.1.1.
 
 --- 
 # DEPRECATED: All builds below this line are deprecated and will not work starting on 8/20/2020


### PR DESCRIPTION
## Description
- Added version 3.1.2 to the CHANGELOG.

## Motivation and Context
Version 3.1.2 of the CirrusMDSDK contains the exact same updates to the pinned certificates as 3.2.2 but it is based off of 3.1.1. Have added this release to the CHANGELOG so that consumers know it is an option.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [x] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
